### PR TITLE
사용자 닉네임 업데이트 기능 추가

### DIFF
--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -9,7 +9,7 @@ type ActionResult = { success: true } | { success: false; error: string }
 // 닉네임 유효성 검사 규칙 - 닉네임 정책
 const USERNAME_MIN_LENGTH = 2
 const USERNAME_MAX_LENGTH = 20
-const USERNAME_PATTERN = /^[a-zA-Z0-9가-힣_]+$/
+const USERNAME_PATTERN = /^[a-zA-Z0-9가-힣_.]+$/
 
 /**
  * 사용자의 닉네임 업데이트 서버 액션
@@ -30,7 +30,7 @@ export async function updateUsername(_prevState: ActionResult | null, formData: 
     }
 
     if (!USERNAME_PATTERN.test(username)) {
-        return { success: false, error: '닉네임은 한글, 영문, 숫자, 밑줄(_)만 사용할 수 있습니다.' }
+        return { success: false, error: '닉네임은 한글, 영문, 숫자, 언더바(_), 온점(.)만 사용할 수 있습니다.' }
     }
 
     // 2. 인증 확인


### PR DESCRIPTION
### 작업 사항
- 사용자 닉네임 업데이트 서버 액션 추가
    - 사용자 닉네임 업데이트 서버 액션
    - 닉네임 유효성 정책 정의
        - 최소 길이: 2
        - 최대 길이: 20
        - 한글, 영문자, 숫자, 언더바(_), 온점(.) 문자만 유효
    - Supabase에서 사용자 테이블 입력 시 기본 닉네임 설정하는 trigger 설정됨

```sql
create or replace function public.handle_new_user()
returns trigger as $$
begin
  insert into profiles (id, username, avatar_url)
  values (
    new.id, 
    split_part(new.email, '@', 1), -- 이메일의 @ 앞부분을 기본 닉네임으로 사용
    new.raw_user_meta_data->>'avatar_url' -- 구글 로그인의 경우 프로필 사진 가져오기
  );
  return new;
end;
```