### PR TITLE
닉네임 설정 시 이미 사용 중인 닉네임은 설정하지 못하도록 체크 로직 추가

### DIFF
--- a/src/app/mypage/action.ts
+++ b/src/app/mypage/action.ts
@@ -17,6 +17,18 @@ export async function updateProfile(formData: FormData) {
     const nickname = String(formData.get('nickname') || '')
     const avatar_url = String(formData.get('avatar_url') || '')
 
+    // 닉네임 중복 검사 (본인 제외)
+    const { data: existingProfile } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('nickname', nickname)
+        .neq('id', user.id)
+        .maybeSingle()
+
+    if (existingProfile) {
+        return { success: false, message: '이미 사용 중인 닉네임입니다.' }
+    }
+
     const { error } = await supabase
         .from('profiles')
         .upsert({


### PR DESCRIPTION
### 작업 사항
- 닉네임 설정 시 중복 체크 로직 추가
    - 본인을 제외한 사용자 중 입력한 닉네임을 사용하는 사용자가 있는지 데이터 조회해보기
- `profiles` 테이블의 `nickname` 컬럼에 UNIQUE 제약 조건 추가

```sql
ALTER TABLE profiles
ADD CONSTRAINT profiles_nickname_key UNIQUE (nickname);
```